### PR TITLE
remove custom required length

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ActiveRecord::Base
   validate :password_complexity
   def password_complexity
     if password.present?
-      if !password.match(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*\-+;:'"])(?=.{8,})/)
+      if !password.match(/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*\-+;:'"])/)
         errors.add :password, "must have a number, lowercase, uppercase and special character"
       end
     end


### PR DESCRIPTION
Devise has a built in required length of 6 (will spit back a "Password must have minimum length 6" message), so it seems just easier to roll with that. 

I tried a password of length 7 with all the character combinations satisfied and it still said "Password must have a number, lowercase, uppercase and special character" because of our manual rule of 8, so just reducing from 8 to the built in 6