### PR TITLE
Add migrations to add missing primary and foreign keys

### DIFF
--- a/db/migrate/20180416205848_add_missing_primary_keys.rb
+++ b/db/migrate/20180416205848_add_missing_primary_keys.rb
@@ -1,0 +1,27 @@
+class AddMissingPrimaryKeys < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER TABLE craftsmen
+        ADD CONSTRAINT employment_id_uniqueness UNIQUE(employment_id);
+
+      ALTER TABLE annual_starting_craftsman_salaries
+        ADD CONSTRAINT location_uniquness UNIQUE(location);
+
+      ALTER TABLE monthly_apprentice_salaries
+        ADD CONSTRAINT duration_location_uniquness UNIQUE(duration, location);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE craftsmen
+        DROP CONSTRAINT employment_id_uniqueness;
+
+      ALTER TABLE annual_starting_craftsman_salaries
+        DROP CONSTRAINT location_uniquness;
+
+      ALTER TABLE monthly_apprentice_salaries
+        DROP CONSTRAINT duration_location_uniquness;
+    SQL
+  end
+end

--- a/db/migrate/20180416211434_add_foreign_keys_to_tables.rb
+++ b/db/migrate/20180416211434_add_foreign_keys_to_tables.rb
@@ -1,0 +1,57 @@
+class AddForeignKeysToTables < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER TABLE applicants
+        ADD CONSTRAINT craftsman_id_fk
+          FOREIGN KEY (craftsman_id)
+          REFERENCES craftsmen (employment_id);
+
+      ALTER TABLE assigned_craftsman_records
+        ADD CONSTRAINT craftsman_id_fk
+          FOREIGN KEY (craftsman_id)
+          REFERENCES craftsmen (id),
+        ADD CONSTRAINT applicant_id_fk
+          FOREIGN KEY (applicant_id)
+          REFERENCES applicants (id);
+
+      ALTER TABLE messages
+        ADD CONSTRAINT applicant_id_fk
+          FOREIGN KEY (applicant_id)
+          REFERENCES applicants (id);
+
+      ALTER TABLE notes
+        ADD CONSTRAINT craftsman_id_fk
+          FOREIGN KEY (craftsman_id)
+          REFERENCES craftsmen (id),
+        ADD CONSTRAINT applicant_id_fk
+          FOREIGN KEY (applicant_id)
+          REFERENCES applicants (id);
+
+      ALTER TABLE users
+        ADD CONSTRAINT craftsman_id_fk
+          FOREIGN KEY (craftsman_id)
+          REFERENCES craftsmen (employment_id);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE applicants
+        DROP CONSTRAINT craftsman_id_fk;
+
+      ALTER TABLE assigned_craftsman_records
+        DROP CONSTRAINT craftsman_id_fk,
+        DROP CONSTRAINT applicant_id_fk;
+
+      ALTER TABLE messages
+        DROP CONSTRAINT applicant_id_fk;
+
+      ALTER TABLE notes
+        DROP CONSTRAINT craftsman_id_fk,
+        DROP CONSTRAINT applicant_id_fk;
+
+      ALTER TABLE users
+        DROP CONSTRAINT craftsman_id_fk;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140904131223) do
+ActiveRecord::Schema.define(version: 20180416211434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20140904131223) do
     t.string "location", null: false
     t.float  "amount",   null: false
   end
+
+  add_index "annual_starting_craftsman_salaries", ["location"], name: "location_uniquness", unique: true, using: :btree
 
   create_table "applicants", force: true do |t|
     t.string   "name"
@@ -86,6 +88,8 @@ ActiveRecord::Schema.define(version: 20140904131223) do
     t.date    "unavailable_until"
   end
 
+  add_index "craftsmen", ["employment_id"], name: "employment_id_uniqueness", unique: true, using: :btree
+
   create_table "friendly_id_slugs", force: true do |t|
     t.string   "slug",                      null: false
     t.integer  "sluggable_id",              null: false
@@ -114,6 +118,8 @@ ActiveRecord::Schema.define(version: 20140904131223) do
     t.string  "location", null: false
     t.float   "amount",   null: false
   end
+
+  add_index "monthly_apprentice_salaries", ["duration", "location"], name: "duration_location_uniquness", unique: true, using: :btree
 
   create_table "notes", force: true do |t|
     t.text     "body"


### PR DESCRIPTION
Couldn't use the `add_foreign_key` helper since we're not on Rails 4.2 yet :( 