### PR TITLE
Let seeds be run in prod

### DIFF
--- a/config/ansible/footprints-public-nossl.conf
+++ b/config/ansible/footprints-public-nossl.conf
@@ -1,12 +1,12 @@
 server {
   #server_name footprints.fun;
-  server_name 18.188.189.207;
+  server_name 18.191.40.34;
   listen 80;
 
   root /home/ubuntu/footprints-public/public;
 
   passenger_enabled on;
-  passenger_ruby /usr/bin/ruby;
+  passenger_ruby /home/ubuntu/.rbenv/versions/2.2.9/bin/ruby;
 
     #listen 443 ssl; # managed by Certbot
     #ssl_certificate /etc/letsencrypt/live/footprints.fun/fullchain.pem; # managed by Certbot

--- a/db/default_seeds.rb
+++ b/db/default_seeds.rb
@@ -384,12 +384,12 @@ module DefaultSeed
 end
 
 
-if Rails.env == "development"
-  DefaultSeed.craftsman
-  DefaultSeed.user
-elsif Rails.env == "staging"
-  DefaultSeed.staging_steward
-end
+#if Rails.env == "development"
+DefaultSeed.craftsman
+DefaultSeed.user
+#elsif Rails.env == "staging"
+#  DefaultSeed.staging_steward
+#end
 
 DefaultSeed.applicant
 DefaultSeed.assign_craftsmen

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
-if Rails.env == "production"
-  puts "Don't run seeds in production!"
-else
-  require "#{Rails.root}/db/default_seeds.rb"
-end
+# if Rails.env == "production"
+#   puts "Don't run seeds in production!"
+# else
+require "#{Rails.root}/db/default_seeds.rb"
+# end


### PR DESCRIPTION
Eric will probably be disappointed but this lets us get actual data up and running immediately after provisioning a server. This won't be necessary when different servers are reading from the same db, but we're not there yet