### PR TITLE
only allow match result to be recorded once

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -11,14 +11,19 @@ class MatchesController < ApplicationController
     @fighter_2 = @match.fighter_2
 
     @winner_id = @match.winner_id
+    @winner_name = User.find_by_id(@winner_id).try(:name)
   end
 
   def update
     match = Match.find(params[:match_id])
 
-    match.update(match_params)
+    if match.winner_id.blank?
+      match.update(match_params)
 
-    redirect_to show_match_path, notice: "Successfully updated match"
+      redirect_to show_match_path, notice: "Successfully updated match"
+    else
+      redirect_to show_match_path, alert: "Sorry! The match result has already been recorded and cannot be changed. Sucks to suck."
+    end
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,12 +36,15 @@
     <% if flash[:notice] %>
       <div id="flash-notices">
         <p class="flash notice"><%= flash[:notice].titleize %></p>
-      <% end %>
-      <% if flash[:error] %>
-        <% flash[:error].each do |e| %>
-          <p class="flash warning"><%= e.titleize.gsub('Url', 'URL') + "." %></p>
-        <% end %>
       </div>
+    <% end %>
+    <% if flash[:alert] %>
+      <p class="flash warning"><%= flash[:alert].titleize %></p>
+    <% end %>
+    <% if flash[:error] %>
+      <% flash[:error].each do |e| %>
+        <p class="flash warning"><%= e.titleize.gsub('Url', 'URL') + "." %></p>
+      <% end %>
     <% end %>
 
     <%= yield %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,8 +1,9 @@
 <div class="container matches">
   <div class="row">
     <div class="column two-third">
-      <h2><%= @fighter_1.name %> VS  <%= @fighter_2.name %><h2>
+      <h2><%= @fighter_1.name %> VS  <%= @fighter_2.name %></h2>
 
+      <% if @winner_id.blank?%>
         <%= form_for @match, :url => match_update_path, :method => "PUT" do |f| %>
           <ul class="profile-list">
             <li>
@@ -14,6 +15,12 @@
             </li>
           </ul>
         <% end %>
-      </div>
+      <% else %>
+        <div class="profile-list">
+          <%= label_tag(:winner_id, "Winner")%>
+          <h3><%= @winner_name %></h3>
+        </div>
+      <% end %>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
Hide the form if the match already has a result.

If the result is updated elsewhere while you already have the match result form open, displays an error after trying to submit